### PR TITLE
Fix/unused args

### DIFF
--- a/src/llm_interface/helpers.py
+++ b/src/llm_interface/helpers.py
@@ -156,6 +156,10 @@ class LlmConversionHelpers:
         parameters = {"type": "object", "properties": {}, "required": []}
 
         for param_name, param in sig.parameters.items():
+            # Skip *args and **kwargs parameters
+            if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+                continue
+
             param_type = type_hints.get(param_name, str)
             param_schema = cls.convert_type_to_json_schema(param_type)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -39,3 +39,22 @@ async def test_function_to_tool_multiline_docstring_and_parameters():
         tool["function"]["parameters"]["properties"]["country"]["description"]
         == f"{param_2_first_line}\n{param_2_additional}"
     )
+
+
+@pytest.mark.asyncio
+async def test_function_to_tool_args_and_kwargs():
+    """Test that we do not include args and kwargs in the tool description"""
+
+    def get_weather(city: str, *args, **kwargs) -> str:
+        """Get the current temperature for a given location
+
+        :param city: City and country e.g. Bogotá, Colombia
+        """
+        return "25 degrees Celsius"
+
+    tool = LlmConversionHelpers.function_to_tool(get_weather)
+    assert (
+        tool["function"]["parameters"]["properties"]["city"]["description"]
+        == "City and country e.g. Bogotá, Colombia"
+    )
+    assert len(tool["function"]["parameters"]["properties"].keys()) == 1


### PR DESCRIPTION
- Make sure *args and **kwargs are not passed to the LLM in the tool definition